### PR TITLE
feat: Add audio file export to file system

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ horologist = "0.7.15"
 coreSplashscreen = "1.0.1"
 wear-input = "1.2.0"
 androidxDataStore = "1.1.7"
+documentfile = "1.0.1"
 #material-icons-extended = "1.7.8"
 
 [libraries]
@@ -63,6 +64,7 @@ wear-input = { group = "androidx.wear", name = "wear-input", version.ref = "wear
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-dataStore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
+androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/mobile/build.gradle.kts
+++ b/mobile/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
   implementation(libs.kotlinx.coroutines.play.services)
   implementation(libs.androidx.dataStore.preferences)
   implementation(libs.androidx.work.ktx)
+  implementation(libs.androidx.documentfile)
 
   implementation(libs.androidx.compose.material.iconsExtended)
 }


### PR DESCRIPTION
Hi tberghuis,

I love your app, but I have a strong desire to export all my audio recordings to a folder on my phone for backup and further processing with other tools (e.g. automatic transcription).

I have no experience in Android programming and create these changes with the help of Opus 4.5 in Android Studio. I tested them so far only in the emulator, which looked good to me. Hopefully this is good enough to be reviewed by you and added as an update to your app. I would really love it! If there is anything else I can or should do to push this forward, let me know.

Description of my changes:
Add ability to export recorded audio files to an external folder:
- Add Export button to the mobile app UI
- Implement folder picker using OpenDocumentTree API
- Copy all recordings to the selected folder with progress feedback
- Add documentfile dependency for SAF support

<img width="767" height="1148" alt="Screenshot_20251220_154135" src="https://github.com/user-attachments/assets/3c480200-e600-44b2-a19e-410303794b28" />