### PR TITLE
fix: Send sync messages to wear devices and auto-refresh recording list

### DIFF
--- a/common/src/main/java/dev/tberghuis/voicememos/common/RecordingsEvent.kt
+++ b/common/src/main/java/dev/tberghuis/voicememos/common/RecordingsEvent.kt
@@ -1,0 +1,17 @@
+package dev.tberghuis.voicememos.common
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Simple event bus for notifying when recordings have been updated.
+ * Used by ProcessZipWorker to signal MobileViewModel to refresh the file list.
+ */
+object RecordingsEvent {
+    private val _recordingsUpdated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val recordingsUpdated = _recordingsUpdated.asSharedFlow()
+
+    fun notifyRecordingsUpdated() {
+        _recordingsUpdated.tryEmit(Unit)
+    }
+}

--- a/mobile/src/main/java/dev/tberghuis/voicememos/MobileViewModel.kt
+++ b/mobile/src/main/java/dev/tberghuis/voicememos/MobileViewModel.kt
@@ -11,6 +11,7 @@ import com.google.android.gms.wearable.CapabilityClient
 import com.google.android.gms.wearable.MessageClient
 import com.google.android.gms.wearable.Wearable
 import dev.tberghuis.voicememos.common.AudioController
+import dev.tberghuis.voicememos.common.RecordingsEvent
 import dev.tberghuis.voicememos.common.deleteFileCommon
 import dev.tberghuis.voicememos.common.logd
 import java.io.File
@@ -51,6 +52,14 @@ class MobileViewModel(private val application: Application) : AndroidViewModel(a
     logd("MobileViewModel init")
     refreshRecordingFiles()
     messageClient.addListener(messageListener)
+    
+    // Listen for recordings updated from ProcessZipWorker
+    viewModelScope.launch {
+      RecordingsEvent.recordingsUpdated.collect {
+        refreshRecordingFiles()
+        snackbarHostState.showSnackbar("Download complete")
+      }
+    }
   }
 
   override fun onCleared() {


### PR DESCRIPTION
## What this PR does
Fixes two related issues:
1. **TARGET_NODE_NOT_CONNECTED error** - The app was incorrectly sending sync messages to the local phone node instead of the connected watch. This caused messages to fail when trying to notify the watch that sync was complete.
2. **Recordings not appearing until app restart** - After downloading recordings from the watch, users had to restart the phone app to see the new files.
## Changes
- **ProcessZipWorker.kt**: Use `CapabilityClient` to find reachable wear devices and send sync messages to them instead of the local node
- **RecordingsEvent.kt** (new): Simple event bus for cross-component communication
- **MobileViewModel.kt**: Listen for recording updates and auto-refresh the file list
## Testing
1. Download recordings from watch to phone
2. Verify no "TARGET_NODE_NOT_CONNECTED" errors in logs
3. Recordings should appear immediately with "Download complete" snackbar